### PR TITLE
Color edge labels by association type

### DIFF
--- a/lib/rails/schema/assets/app.js
+++ b/lib/rails/schema/assets/app.js
@@ -413,7 +413,7 @@
       .attr("class", "edge-label-bg");
 
     eGroups.append("text")
-      .attr("class", "edge-label")
+      .attr("class", function(d) { return "edge-label " + d.data.association_type; })
       .attr("text-anchor", "middle")
       .attr("dy", -6)
       .text(function(d) { return d.data.label; });

--- a/lib/rails/schema/assets/style.css
+++ b/lib/rails/schema/assets/style.css
@@ -346,6 +346,14 @@ body {
   pointer-events: none;
 }
 
+.edge-label.belongs_to { fill: var(--edge-belongs-to); }
+.edge-label.has_many { fill: var(--edge-has-many); }
+.edge-label.has_one { fill: var(--edge-has-one); }
+.edge-label.has_and_belongs_to_many { fill: var(--edge-habtm); }
+.edge-label.embeds_many { fill: var(--edge-embeds-many); }
+.edge-label.embeds_one { fill: var(--edge-embeds-one); }
+.edge-label.embedded_in { fill: var(--edge-embedded-in); }
+
 .edge-label-bg {
   fill: var(--bg-primary);
   opacity: 0.85;


### PR DESCRIPTION
Apply the association type as a CSS class on edge label text elements so labels inherit the same color as their corresponding edge lines.

Closes #18