### PR TITLE
Add double-click to focus node neighborhood (#6)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,7 +96,7 @@ Single self-contained HTML file — no CDN, no network requests. D3 is vendored/
 
 - **Vanilla JS + d3-force** for graph rendering
 - **CSS custom properties** for dark/light theming
-- Features: searchable sidebar, click-to-focus, detail panel, zoom/pan, keyboard shortcuts (`/` search, `Esc` deselect, `+/-` zoom, `F` fit)
+- Features: searchable sidebar, click-to-focus, double-click to isolate neighborhood, detail panel, zoom/pan, keyboard shortcuts (`/` search, `Esc` deselect, `+/-` zoom, `F` fit)
 
 ## Design Decisions
 

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ For Mongoid apps, the gem introspects model classes at runtime to read field def
 - **Force-directed layout** — models cluster naturally by association density; self-referential-only models are placed in a left column, true orphans in rows above
 - **Searchable sidebar** — filter models by name or table
 - **Click-to-focus** — click a model to highlight its neighborhood, fading unrelated models
+- **Double-click to isolate** — double-click a model to filter the view to only that model and its direct neighbors
 - **Detail panel** — full column list and associations for the selected model
 - **Dark/light theme** — toggle or auto-detect from system preference
 - **Zoom & pan** — scroll wheel, pinch, or buttons

--- a/lib/rails/schema/assets/app.js
+++ b/lib/rails/schema/assets/app.js
@@ -433,6 +433,10 @@
       .on("click", function(event, d) {
         event.stopPropagation();
         selectNode(d.id);
+      })
+      .on("dblclick", function(event, d) {
+        event.stopPropagation();
+        focusNeighborhood(d.id);
       });
 
     // Background rect
@@ -670,6 +674,7 @@
     });
 
   svg.call(zoom);
+  svg.on("dblclick.zoom", null);
 
   // Click background to deselect
   svg.on("click", function() {
@@ -694,6 +699,17 @@
 
     showDetailPanel(nodeId);
     updateSidebarActive(nodeId);
+  }
+
+  function focusNeighborhood(nodeId) {
+    var neighbors = adjacency[nodeId] || new Set();
+    visibleModels.clear();
+    visibleModels.add(nodeId);
+    neighbors.forEach(function(id) { visibleModels.add(id); });
+    buildSidebar();
+    render();
+    selectNode(nodeId);
+    setTimeout(fitToScreen, 100);
   }
 
   function deselectNode() {


### PR DESCRIPTION
Double-clicking a node filters the view to show only that node and its directly connected neighbors, then fits the view to screen. Disables d3's default double-click-to-zoom to avoid conflicts.