### PR TITLE
Add support for showing :through edges in schema diagram

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,7 +102,8 @@ Single self-contained HTML file — no CDN, no network requests. D3 is vendored/
 
 - **Vanilla JS + d3-force** for graph rendering
 - **CSS custom properties** for dark/light theming
-- Features: searchable sidebar, click-to-focus, double-click to isolate neighborhood, detail panel, zoom/pan, keyboard shortcuts (`/` search, `Esc` deselect, `+/-` zoom, `F` fit), Mermaid ER diagram export (`.mmd`) filtered by sidebar visibility
+- Features: searchable sidebar, click-to-focus, double-click to isolate neighborhood, detail panel (clicking a relation link auto-selects the related model, adding it to the diagram if hidden), zoom/pan, keyboard shortcuts (`/` search, `Esc` deselect, `+/-` zoom, `F` fit), Mermaid ER diagram export (`.mmd`) filtered by sidebar visibility
+- **Through edges toggle** — legend checkbox to show/hide `:through` edges on the diagram at runtime; `config.show_through_edges` (default `true`) sets the initial checkbox state; through associations always remain visible in the detail panel regardless of toggle state; filtering happens in `setupSimulation()` on the frontend (edges stay in `data.edges` for the detail panel)
 - **Select All smart toggle** — when all models are already selected and a search filter is active, "Select All" narrows to only filtered models (acts as "select only these"); otherwise it adds filtered models to the current selection
 - **Model grouping** — when `config.model_schema_group` is set, models are organized under collapsible group headers in the sidebar with color-coded dots; each group's models get a distinct node header color in the SVG; a custom d3 force (`strength 0.15`) pulls same-group nodes toward their centroid, and a separation force pushes overlapping group bounding boxes apart; double-click a group header to select/deselect (uses delayed click timer to avoid triggering collapse); search also matches group names
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Rails::Schema.configure do |config|
   config.exclude_model_if = ->(model) { model.table_name.start_with?("_") }
   config.model_schema_group = :namespaces  # group models by Ruby namespace
   config.collapse_groups = true            # start with groups collapsed
+  config.show_through_edges = true         # show :through edges on the diagram
 end
 ```
 
@@ -78,6 +79,7 @@ end
 | `exclude_model_if` | `nil` | A proc/lambda that receives a model class and returns `true` to exclude it |
 | `model_schema_group` | `nil` | Group models visually — `:namespaces`, or a custom proc (see below) |
 | `collapse_groups` | `true` | Whether sidebar groups start collapsed |
+| `show_through_edges` | `true` | Whether `:through` association edges are shown on the diagram initially (toggleable at runtime via legend checkbox) |
 
 ### Schema format
 
@@ -166,7 +168,8 @@ If the targeted loading doesn't find any models, the gem falls back to a full ea
 - **Shift-click range selection** — hold Shift and click checkboxes to toggle a range at once
 - **Click-to-focus** — click a model to highlight its neighborhood, fading unrelated models
 - **Double-click to isolate** — double-click a model to filter the view to only that model and its direct neighbors
-- **Detail panel** — full column list and associations for the selected model
+- **Through edges toggle** — checkbox in the legend to show/hide `:through` association edges on the diagram; through associations always remain visible in the detail panel regardless of toggle state
+- **Detail panel** — full column list and associations for the selected model; clicking a relation link auto-selects the related model (adding it to the diagram if hidden)
 - **Dark/light theme** — toggle or auto-detect from system preference
 - **Zoom & pan** — scroll wheel, pinch, or buttons
 - **Keyboard shortcuts** — `/` search, `Esc` deselect, `+/-` zoom, `F` fit to screen

--- a/lib/rails/schema/assets/app.js
+++ b/lib/rails/schema/assets/app.js
@@ -14,6 +14,17 @@
       el.style.display = "none";
     });
   }
+  // Through edges toggle
+  var showThroughEdges = config.show_through_edges !== false;
+  var throughCheckbox = document.getElementById("toggle-through");
+  if (throughCheckbox) {
+    throughCheckbox.checked = showThroughEdges;
+    throughCheckbox.addEventListener("change", function() {
+      showThroughEdges = this.checked;
+      render();
+      if (selectedNode) selectNode(selectedNode);
+    });
+  }
 
   // State
   var selectedNode = null;
@@ -236,6 +247,7 @@
     nodes.forEach(function(n) { nodeMap[n.id] = n; });
 
     var simEdges = edges.filter(function(e) {
+      if (!showThroughEdges && e.through) return false;
       return visibleModels.has(e.from) && visibleModels.has(e.to);
     }).map(function(e) {
       return { source: e.from, target: e.to, data: e };
@@ -913,7 +925,14 @@
     // Click association targets to navigate
     content.querySelectorAll('.assoc-target').forEach(function(el) {
       el.addEventListener('click', function() {
-        selectNode(el.dataset.model);
+        var modelId = el.dataset.model;
+        if (!visibleModels.has(modelId)) {
+          visibleModels.add(modelId);
+          buildSidebar();
+          render();
+          setTimeout(fitToScreen, 100);
+        }
+        selectNode(modelId);
       });
     });
   }

--- a/lib/rails/schema/assets/style.css
+++ b/lib/rails/schema/assets/style.css
@@ -549,6 +549,15 @@ body {
   gap: 4px;
 }
 
+.legend-toggle {
+  cursor: pointer;
+}
+
+.legend-toggle input[type="checkbox"] {
+  margin: 0;
+  cursor: pointer;
+}
+
 .legend-line {
   width: 20px;
   height: 2px;

--- a/lib/rails/schema/assets/template.html.erb
+++ b/lib/rails/schema/assets/template.html.erb
@@ -32,7 +32,7 @@
         <span class="legend-item"><span class="legend-line habtm"></span> habtm (M:M)</span>
         <span class="legend-item" data-mode="mongoid"><span class="legend-line embeds_many"></span> embeds_many</span>
         <span class="legend-item" data-mode="mongoid"><span class="legend-line embeds_one"></span> embeds_one</span>
-        <span class="legend-item" data-mode="active_record"><span class="legend-line through"></span> :through</span>
+        <label class="legend-item legend-toggle" data-mode="active_record"><input type="checkbox" id="toggle-through" checked><span class="legend-line through"></span> :through</label>
         <span class="legend-item"><span class="legend-line polymorphic"></span> polymorphic</span>
       </div>
       <div class="spacer"></div>

--- a/lib/rails/schema/configuration.rb
+++ b/lib/rails/schema/configuration.rb
@@ -4,7 +4,7 @@ module Rails
   module Schema
     class Configuration
       attr_accessor :output_path, :exclude_models, :exclude_model_if, :title, :theme, :expand_columns, :schema_format,
-                    :model_schema_group, :collapse_groups
+                    :model_schema_group, :collapse_groups, :show_through_edges
 
       def initialize
         @output_path = "docs/schema.html"
@@ -16,6 +16,7 @@ module Rails
         @schema_format = :auto
         @model_schema_group = nil
         @collapse_groups = true
+        @show_through_edges = true
       end
 
       def resolved_group_proc

--- a/lib/rails/schema/renderer/html_generator.rb
+++ b/lib/rails/schema/renderer/html_generator.rb
@@ -63,7 +63,8 @@ module Rails
             expand_columns: @configuration.expand_columns,
             theme: @configuration.theme.to_s,
             grouping_enabled: !@configuration.model_schema_group.nil?,
-            collapse_groups: @configuration.collapse_groups
+            collapse_groups: @configuration.collapse_groups,
+            show_through_edges: @configuration.show_through_edges
           }
           JSON.generate(config).gsub("</", '<\/')
         end

--- a/spec/rails/schema/configuration_spec.rb
+++ b/spec/rails/schema/configuration_spec.rb
@@ -35,6 +35,10 @@ RSpec.describe Rails::Schema::Configuration do
     expect(config.model_schema_group).to be_nil
   end
 
+  it "has default show_through_edges" do
+    expect(config.show_through_edges).to eq(true)
+  end
+
   describe "#resolved_group_proc" do
     it "returns nil when model_schema_group is nil" do
       expect(config.resolved_group_proc).to be_nil

--- a/spec/rails/schema/transformer/graph_builder_spec.rb
+++ b/spec/rails/schema/transformer/graph_builder_spec.rb
@@ -168,6 +168,38 @@ RSpec.describe Rails::Schema::Transformer::GraphBuilder do
     end
   end
 
+  describe "#build always includes through edges in data" do
+    let(:model_a) { double("ModelA", name: "Author", table_name: "authors") }
+    let(:model_b) { double("ModelB", name: "Book", table_name: "books") }
+    let(:model_c) { double("ModelC", name: "Review", table_name: "reviews") }
+
+    let(:column_reader) { instance_double(Rails::Schema::Extractor::ColumnReader) }
+    let(:association_reader) { instance_double(Rails::Schema::Extractor::AssociationReader) }
+
+    before do
+      allow(column_reader).to receive(:read).and_return([])
+      allow(association_reader).to receive(:read).with(model_a).and_return([
+        { from: "Author", to: "Book", association_type: "has_many", label: "books",
+          foreign_key: "author_id", through: nil, polymorphic: false },
+        { from: "Author", to: "Review", association_type: "has_many", label: "reviews",
+          foreign_key: "author_id", through: "books", polymorphic: false }
+      ])
+      allow(association_reader).to receive(:read).with(model_b).and_return([])
+      allow(association_reader).to receive(:read).with(model_c).and_return([])
+    end
+
+    let(:builder) { described_class.new(column_reader: column_reader, association_reader: association_reader) }
+
+    it "includes through edges regardless of show_through_edges config" do
+      Rails::Schema.configure { |c| c.show_through_edges = false }
+      result = builder.build([model_a, model_b, model_c])
+      labels = result[:edges].map { |e| e[:label] }
+
+      expect(labels).to include("books")
+      expect(labels).to include("reviews")
+    end
+  end
+
   describe "#build with duplicate model names" do
     let(:dup_model_a) do
       double("DupModelA", name: "HABTM_Things", table_name: "things_roles")

--- a/spec/rails/schema/transformer/graph_builder_spec.rb
+++ b/spec/rails/schema/transformer/graph_builder_spec.rb
@@ -178,12 +178,14 @@ RSpec.describe Rails::Schema::Transformer::GraphBuilder do
 
     before do
       allow(column_reader).to receive(:read).and_return([])
-      allow(association_reader).to receive(:read).with(model_a).and_return([
-        { from: "Author", to: "Book", association_type: "has_many", label: "books",
-          foreign_key: "author_id", through: nil, polymorphic: false },
-        { from: "Author", to: "Review", association_type: "has_many", label: "reviews",
-          foreign_key: "author_id", through: "books", polymorphic: false }
-      ])
+      allow(association_reader).to receive(:read).with(model_a).and_return(
+        [
+          { from: "Author", to: "Book", association_type: "has_many", label: "books",
+            foreign_key: "author_id", through: nil, polymorphic: false },
+          { from: "Author", to: "Review", association_type: "has_many", label: "reviews",
+            foreign_key: "author_id", through: "books", polymorphic: false }
+        ]
+      )
       allow(association_reader).to receive(:read).with(model_b).and_return([])
       allow(association_reader).to receive(:read).with(model_c).and_return([])
     end


### PR DESCRIPTION
- Introduced `show_through_edges` configuration option to control visibility of :through edges.
- Updated README to document the new configuration option.
- Enhanced JavaScript to toggle :through edges based on user selection.
- Modified HTML template to include a checkbox for toggling :through edges.
- Updated CSS for styling the toggle checkbox.
- Adjusted HTML generator to include the new configuration in the output.
- Added tests to ensure :through edges are included in the data regardless of the toggle state.