### PR TITLE
Fix SQLite structure.sql parsing producing empty models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.1.8] - 2026-06-14
+
+### Fixed
+
+- SQLite `structure.sql` parsing — `StructureSqlParser` now correctly extracts all columns from SQLite-format dumps, which place the entire `CREATE TABLE` on a single line. Previously only the primary key was read (every model rendered with just its `id`). Column splitting is now parenthesis- and quote-aware, so commas inside type modifiers (`decimal(5,4)`), `FOREIGN KEY` clauses, and string literals no longer break parsing; inline C-style comments (`/* ... */`) are stripped. PostgreSQL `pg_dump` output continues to parse as before.
+
 ## [0.1.7] - 2026-04-25
 
 ### Added

--- a/lib/rails/schema/extractor/structure_sql_parser.rb
+++ b/lib/rails/schema/extractor/structure_sql_parser.rb
@@ -67,8 +67,8 @@ module Rails
         def parse_table_body(body)
           columns = []
           pk_columns = []
-          body.each_line do |raw|
-            line = raw.strip.chomp(",")
+          split_columns(body).each do |segment|
+            line = segment.strip
             next if line.empty?
 
             if (pk = extract_pk_constraint(line))
@@ -79,6 +79,50 @@ module Rails
             end
           end
           [columns, pk_columns]
+        end
+
+        # Splits a table body on top-level commas, ignoring commas inside
+        # parentheses (e.g. decimal(5,4), FK clauses) or quoted strings. This
+        # handles both PostgreSQL (one column per line) and SQLite (whole table
+        # on a single line) structure.sql dumps.
+        def split_columns(body)
+          segments = []
+          current = +""
+          state = { depth: 0, squote: false, dquote: false }
+          strip_comments(body).each_char do |ch|
+            if split_point?(ch, state)
+              segments << current
+              current = +""
+            else
+              current << ch
+            end
+          end
+          segments << current
+        end
+
+        def split_point?(char, state)
+          toggle_quote(char, state)
+          return false if quoted?(state)
+
+          case char
+          when "(" then state[:depth] += 1
+          when ")" then state[:depth] -= 1
+          when "," then return state[:depth].zero?
+          end
+          false
+        end
+
+        def toggle_quote(char, state)
+          state[:squote] = !state[:squote] if char == "'" && !state[:dquote]
+          state[:dquote] = !state[:dquote] if char == '"' && !state[:squote]
+        end
+
+        def quoted?(state)
+          state[:squote] || state[:dquote]
+        end
+
+        def strip_comments(sql)
+          sql.gsub(%r{/\*.*?\*/}m, "")
         end
 
         def extract_pk_constraint(line)

--- a/lib/rails/schema/version.rb
+++ b/lib/rails/schema/version.rb
@@ -2,6 +2,6 @@
 
 module Rails
   module Schema
-    VERSION = "0.1.7"
+    VERSION = "0.1.8"
   end
 end

--- a/spec/rails/schema/extractor/structure_sql_parser_spec.rb
+++ b/spec/rails/schema/extractor/structure_sql_parser_spec.rb
@@ -341,6 +341,56 @@ RSpec.describe Rails::Schema::Extractor::StructureSqlParser do
     it "returns empty hash for empty content" do
       expect(parser.parse_content("")).to eq({})
     end
+
+    context "with SQLite-format dumps (whole table on one line)" do
+      it "parses all columns from a single-line CREATE TABLE" do
+        content = <<~SQL
+          CREATE TABLE IF NOT EXISTS "users" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "email" varchar NOT NULL, "name" varchar, "created_at" datetime(6) NOT NULL);
+        SQL
+
+        result = parser.parse_content(content)
+        cols = result["users"]
+
+        expect(cols.map { |c| c[:name] }).to eq(%w[id email name created_at])
+        expect(cols.find { |c| c[:name] == "id" }[:primary]).to be true
+        expect(cols.find { |c| c[:name] == "email" }[:nullable]).to be false
+      end
+
+      it "does not split on commas inside type modifiers like decimal(5,4)" do
+        content = <<~SQL
+          CREATE TABLE IF NOT EXISTS "invoices" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "tax_rate" decimal(5,4) DEFAULT 0.0 NOT NULL, "total_cents" integer DEFAULT 0 NOT NULL);
+        SQL
+
+        result = parser.parse_content(content)
+        cols = result["invoices"]
+
+        expect(cols.map { |c| c[:name] }).to eq(%w[id tax_rate total_cents])
+        expect(cols.find { |c| c[:name] == "tax_rate" }[:type]).to eq("decimal")
+      end
+
+      it "does not split on commas inside FOREIGN KEY clauses" do
+        content = <<~SQL
+          CREATE TABLE IF NOT EXISTS "memberships" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "account_id" integer NOT NULL, "user_id" integer NOT NULL, CONSTRAINT "fk_a" FOREIGN KEY ("account_id") REFERENCES "accounts" ("id"), CONSTRAINT "fk_b" FOREIGN KEY ("user_id") REFERENCES "users" ("id"));
+        SQL
+
+        result = parser.parse_content(content)
+        cols = result["memberships"]
+
+        expect(cols.map { |c| c[:name] }).to eq(%w[id account_id user_id])
+      end
+
+      it "strips inline C-style comments" do
+        content = <<~SQL
+          CREATE TABLE IF NOT EXISTS "accounts" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "balance" integer DEFAULT 0 NOT NULL /*application='Fieldo'*/, "terms" integer DEFAULT 30 NOT NULL /*application='Fieldo'*/);
+        SQL
+
+        result = parser.parse_content(content)
+        cols = result["accounts"]
+
+        expect(cols.map { |c| c[:name] }).to eq(%w[id balance terms])
+        expect(cols.find { |c| c[:name] == "terms" }[:type]).to eq("integer")
+      end
+    end
   end
 
   describe "#parse" do


### PR DESCRIPTION
## Problem

When a project uses **SQLite** (`db/structure.sql`), every model in the generated diagram rendered with only its primary key — no other columns. Discovered while generating the diagram for a real SQLite Rails app where all 19 models came out as `id`-only.

## Root cause

`StructureSqlParser#parse_table_body` split table bodies with `body.each_line`, assuming the PostgreSQL `pg_dump` format of one column per physical line. SQLite dumps the entire `CREATE TABLE` on a **single line**, so `each_line` yielded the whole body as one "line" and only the first token (`"id"`) was extracted.

## Fix

Replaced the line-based split with a parenthesis- and quote-aware top-level comma splitter (`split_columns`). It splits on commas only at paren depth 0 and outside quotes, so it works for **both** PostgreSQL (multi-line) and SQLite (single-line) dumps. It also:

- preserves commas inside type modifiers (`decimal(5,4)`)
- preserves commas inside `FOREIGN KEY (...) REFERENCES (...)` clauses and string literals
- strips inline C-style comments (`/* ... */`) that SQLite emits

## Tests

Added 4 SQLite-format specs (single-line table, `decimal(5,4)`, FK clauses, inline comments). All existing PostgreSQL specs still pass — 189 examples, 0 failures; RuboCop clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)