### PR TITLE
Add SQL view support to the schema diagram

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [0.1.8] - 2026-06-14
 
+### Added
+
+- SQL view support — models backed by a SQL view (`CREATE VIEW`, e.g. `self.table_name = "some_view"`) now appear on the diagram instead of being silently dropped. `StructureSqlParser` parses `CREATE VIEW` statements (column names from the SQLite hint comment or the `SELECT` list); columns are read from live DB introspection when a connection is available (accurate types) and fall back to the parsed names offline. View nodes are visually distinguished with a "VIEW" badge and a dashed border, plus a "VIEW" tag in the detail panel.
+
 ### Fixed
 
 - SQLite `structure.sql` parsing — `StructureSqlParser` now correctly extracts all columns from SQLite-format dumps, which place the entire `CREATE TABLE` on a single line. Previously only the primary key was read (every model rendered with just its `id`). Column splitting is now parenthesis- and quote-aware, so commas inside type modifiers (`decimal(5,4)`), `FOREIGN KEY` clauses, and string literals no longer break parsing; inline C-style comments (`/* ... */`) are stripped. PostgreSQL `pg_dump` output continues to parse as before.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,9 +47,10 @@ end
 ### Data Extraction Strategy
 
 1. **`db/schema.rb`** — `SchemaFileParser` parses with regex (table names, columns, types, nullable, defaults, PKs)
-2. **`db/structure.sql`** — `StructureSqlParser` parses SQL `CREATE TABLE` statements, maps SQL types to Rails types
+2. **`db/structure.sql`** — `StructureSqlParser` parses SQL `CREATE TABLE` statements, maps SQL types to Rails types. Column splitting is parenthesis/quote-aware (a top-level-comma splitter), so it handles both PostgreSQL `pg_dump` (one column per line) and SQLite (whole table on one line) dumps. Also parses `CREATE VIEW` statements — view names go into `#views` (a Set), and view column names come from the SQLite hint comment (`/* viewname(col,...) */`) or the `SELECT` list
 3. **ActiveRecord reflection API** — `AssociationReader` uses `reflect_on_all_associations` for associations
 4. **`Model.columns`** — `ColumnReader` falls back to this when table not found in schema_data
+5. **SQL views** — `parse_schema` returns `[columns, view_names]`. `ColumnReader.new(view_tables:)` reads view columns from live DB introspection first (accurate types), falling back to the parsed names offline. `GraphBuilder.new(view_tables:)` sets `Node#view`, which the frontend renders with a "VIEW" badge + dashed border. Views are always included (no config flag); the model just needs `self.table_name` pointing at the view
 
 ### Model Discovery
 

--- a/lib/rails/schema.rb
+++ b/lib/rails/schema.rb
@@ -52,10 +52,10 @@ module Rails
       private
 
       def generate_active_record(output:)
-        schema_data = parse_schema
+        schema_data, views = parse_schema
         models = Extractor::ModelScanner.new(schema_data: schema_data).scan
-        column_reader = Extractor::ColumnReader.new(schema_data: schema_data)
-        graph_data = Transformer::GraphBuilder.new(column_reader: column_reader).build(models)
+        column_reader = Extractor::ColumnReader.new(schema_data: schema_data, view_tables: views)
+        graph_data = Transformer::GraphBuilder.new(column_reader: column_reader, view_tables: views).build(models)
         graph_data[:metadata][:mode] = "active_record"
         generator = Renderer::HtmlGenerator.new(graph_data: graph_data)
         generator.render_to_file(output)
@@ -84,16 +84,23 @@ module Rails
         generator.render_to_file(output)
       end
 
+      # Returns [columns_by_table, view_table_names]. For :auto, falls through
+      # to structure.sql when schema.rb yields nothing.
       def parse_schema
         case configuration.schema_format
         when :ruby
-          Extractor::SchemaFileParser.new.parse
+          parse_with(Extractor::SchemaFileParser.new)
         when :sql
-          Extractor::StructureSqlParser.new.parse
+          parse_with(Extractor::StructureSqlParser.new)
         when :auto
-          data = Extractor::SchemaFileParser.new.parse
-          data.empty? ? Extractor::StructureSqlParser.new.parse : data
+          columns, views = parse_with(Extractor::SchemaFileParser.new)
+          columns.empty? ? parse_with(Extractor::StructureSqlParser.new) : [columns, views]
         end
+      end
+
+      def parse_with(parser)
+        columns = parser.parse
+        [columns, parser.views]
       end
     end
   end

--- a/lib/rails/schema/assets/app.js
+++ b/lib/rails/schema/assets/app.js
@@ -58,6 +58,7 @@
   var NODE_HEADER_HEIGHT = 36;
   var NODE_COLUMN_HEIGHT = 18;
   var NODE_PADDING = 8;
+  var VIEW_BADGE_WIDTH = 34;
 
   // Layout persistence
   function computeFingerprint() {
@@ -755,12 +756,21 @@
       .attr("dominant-baseline", "central")
       .text(function(d) { return truncateText(d.table_name, NODE_WIDTH - NODE_PADDING * 2, "10px " + getComputedStyle(document.body).fontFamily); });
 
-    // VIEW badge (top-right of header) for view-backed models
-    nGroups.filter(function(d) { return d.view; }).append("text")
+    // VIEW badge — a pill floating just above the node, centered, for view-backed models
+    var viewNodes = nGroups.filter(function(d) { return d.view; });
+    viewNodes.append("rect")
+      .attr("class", "node-view-badge-bg")
+      .attr("width", VIEW_BADGE_WIDTH)
+      .attr("height", 13)
+      .attr("rx", 3)
+      .attr("ry", 3)
+      .attr("x", -VIEW_BADGE_WIDTH / 2)
+      .attr("y", function(d) { return -d._height / 2 - 16; });
+    viewNodes.append("text")
       .attr("class", "node-view-badge")
-      .attr("x", NODE_WIDTH / 2 - 6)
-      .attr("y", function(d) { return -d._height / 2 + 11; })
-      .attr("text-anchor", "end")
+      .attr("x", 0)
+      .attr("y", function(d) { return -d._height / 2 - 9; })
+      .attr("text-anchor", "middle")
       .attr("dominant-baseline", "central")
       .text("VIEW");
 

--- a/lib/rails/schema/assets/app.js
+++ b/lib/rails/schema/assets/app.js
@@ -707,7 +707,7 @@
 
     // Background rect
     nGroups.append("rect")
-      .attr("class", "node-rect")
+      .attr("class", function(d) { return "node-rect" + (d.view ? " is-view" : ""); })
       .attr("width", NODE_WIDTH)
       .attr("height", function(d) { return d._height; })
       .attr("x", -NODE_WIDTH / 2)
@@ -754,6 +754,15 @@
       .attr("text-anchor", "middle")
       .attr("dominant-baseline", "central")
       .text(function(d) { return truncateText(d.table_name, NODE_WIDTH - NODE_PADDING * 2, "10px " + getComputedStyle(document.body).fontFamily); });
+
+    // VIEW badge (top-right of header) for view-backed models
+    nGroups.filter(function(d) { return d.view; }).append("text")
+      .attr("class", "node-view-badge")
+      .attr("x", NODE_WIDTH / 2 - 6)
+      .attr("y", function(d) { return -d._height / 2 + 11; })
+      .attr("text-anchor", "end")
+      .attr("dominant-baseline", "central")
+      .text("VIEW");
 
     // Columns
     nGroups.each(function(d) {
@@ -1034,7 +1043,9 @@
     html += '<h2 title="' + escapeHtml(node.id) + '">' + escapeHtml(node.id) + '</h2>';
     html += '<button id="detail-close" onclick="window.__closeDetail()">&times;</button>';
     html += '</div>';
-    html += '<div class="detail-table" title="' + escapeHtml(node.table_name) + '">' + escapeHtml(node.table_name) + '</div>';
+    html += '<div class="detail-table" title="' + escapeHtml(node.table_name) + '">' + escapeHtml(node.table_name);
+    if (node.view) html += ' <span class="detail-view-tag">VIEW</span>';
+    html += '</div>';
 
     html += '<h3>Columns</h3>';
     html += '<ul class="column-list">';

--- a/lib/rails/schema/assets/style.css
+++ b/lib/rails/schema/assets/style.css
@@ -364,6 +364,19 @@ body {
   stroke-width: 2.5;
 }
 
+.node-rect.is-view {
+  stroke-dasharray: 5 3;
+}
+
+.node-view-badge {
+  fill: var(--node-header-text);
+  font-size: 8px;
+  font-weight: 700;
+  letter-spacing: 0.5px;
+  opacity: 0.85;
+  font-family: inherit;
+}
+
 .node-header-rect {
   fill: var(--node-header-bg);
   rx: 8;
@@ -502,6 +515,18 @@ body {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+#detail-content .detail-view-tag {
+  display: inline-block;
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.5px;
+  color: var(--node-header-text);
+  background: var(--accent);
+  border-radius: 3px;
+  padding: 1px 5px;
+  vertical-align: middle;
 }
 
 #detail-content h3 {

--- a/lib/rails/schema/assets/style.css
+++ b/lib/rails/schema/assets/style.css
@@ -368,12 +368,15 @@ body {
   stroke-dasharray: 5 3;
 }
 
+.node-view-badge-bg {
+  fill: var(--accent);
+}
+
 .node-view-badge {
-  fill: var(--node-header-text);
+  fill: #ffffff;
   font-size: 8px;
   font-weight: 700;
   letter-spacing: 0.5px;
-  opacity: 0.85;
   font-family: inherit;
 }
 

--- a/lib/rails/schema/extractor/column_reader.rb
+++ b/lib/rails/schema/extractor/column_reader.rb
@@ -1,15 +1,20 @@
 # frozen_string_literal: true
 
+require "set"
+
 module Rails
   module Schema
     module Extractor
       class ColumnReader
-        def initialize(schema_data: nil)
+        def initialize(schema_data: nil, view_tables: nil)
           @schema_data = schema_data
+          @view_tables = view_tables ? Set.new(view_tables) : Set.new
         end
 
         def read(model)
-          if @schema_data&.key?(model.table_name)
+          if @view_tables.include?(model.table_name)
+            read_view(model)
+          elsif @schema_data&.key?(model.table_name)
             @schema_data[model.table_name]
           else
             read_from_model(model)
@@ -17,6 +22,16 @@ module Rails
         end
 
         private
+
+        # Views have no column types in their DDL, so prefer live DB
+        # introspection (accurate names + types) and fall back to the parsed
+        # column names when no database connection is available.
+        def read_view(model)
+          from_db = read_from_model(model)
+          return from_db unless from_db.empty?
+
+          @schema_data&.fetch(model.table_name, []) || []
+        end
 
         def read_from_model(model)
           model.columns.map do |col|

--- a/lib/rails/schema/extractor/schema_file_parser.rb
+++ b/lib/rails/schema/extractor/schema_file_parser.rb
@@ -1,11 +1,19 @@
 # frozen_string_literal: true
 
+require "set"
+
 module Rails
   module Schema
     module Extractor
       class SchemaFileParser
+        # schema.rb does not declare SQL views, so this is always empty; the
+        # reader exists so SchemaFileParser and StructureSqlParser share an
+        # interface (see Rails::Schema.parse_schema).
+        attr_reader :views
+
         def initialize(schema_path = nil)
           @schema_path = schema_path
+          @views = Set.new
         end
 
         def parse

--- a/lib/rails/schema/extractor/structure_sql_parser.rb
+++ b/lib/rails/schema/extractor/structure_sql_parser.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "set"
+
 module Rails
   module Schema
     module Extractor
@@ -23,8 +25,14 @@ module Rails
         CONSTRAINT_RE = /\A(CONSTRAINT|UNIQUE|CHECK|EXCLUDE|FOREIGN\s+KEY)\b/i.freeze
         PK_CONSTRAINT_RE = /PRIMARY\s+KEY\s*\(([^)]+)\)/i.freeze
 
+        # Set of table names that are backed by SQL views (CREATE VIEW), not
+        # real tables. Populated by #parse / #parse_content. Lets downstream
+        # code badge view-backed models on the diagram.
+        attr_reader :views
+
         def initialize(structure_path = nil)
           @structure_path = structure_path
+          @views = Set.new
         end
 
         def parse
@@ -36,6 +44,7 @@ module Rails
 
         def parse_content(content)
           tables = {}
+          @views = Set.new
 
           content.scan(/CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?([\w."]+)\s*\((.*?)\)\s*;/mi) do |table_name, body|
             name = extract_table_name(table_name)
@@ -44,10 +53,51 @@ module Rails
             tables[name] = columns
           end
 
+          parse_views(content, tables)
           tables
         end
 
         private
+
+        # Views carry no column-type information in their DDL, so offline we can
+        # only recover column names (from the SQLite hint comment or the SELECT
+        # list). ColumnReader prefers live DB introspection for views when a
+        # connection is available; these names are the offline fallback.
+        def parse_views(content, tables)
+          content.scan(/CREATE\s+VIEW\s+([\w."]+)\s+AS\b(.*?);/mi) do |raw_name, body|
+            name = extract_table_name(raw_name)
+            @views << name
+            tables[name] = view_columns(name, body)
+          end
+        end
+
+        def view_columns(name, body)
+          view_column_names(name, body).map do |col_name|
+            { name: col_name, type: "", nullable: true, default: nil, primary: false }
+          end
+        end
+
+        def view_column_names(name, body)
+          if (match = body.match(%r{/\*\s*#{Regexp.escape(name)}\s*\(([^)]*)\)\s*\*/}))
+            match[1].split(",").map { |c| unquote(c.strip) }
+          else
+            select_list_aliases(body)
+          end
+        end
+
+        def select_list_aliases(body)
+          match = body.match(/\bSELECT\b(.*?)\bFROM\b/mi)
+          return [] unless match
+
+          split_columns(match[1]).filter_map { |item| column_alias(item) }
+        end
+
+        def column_alias(item)
+          item = strip_comments(item).strip
+          return nil if item.empty? || item.include?("*")
+
+          item[/\bAS\s+"?(\w+)"?\s*\z/i, 1] || item[/"?(\w+)"?\s*\z/, 1]
+        end
 
         def resolve_path
           return @structure_path if @structure_path

--- a/lib/rails/schema/transformer/graph_builder.rb
+++ b/lib/rails/schema/transformer/graph_builder.rb
@@ -7,10 +7,11 @@ module Rails
     module Transformer
       class GraphBuilder
         def initialize(column_reader: Extractor::ColumnReader.new, association_reader: Extractor::AssociationReader.new,
-                       configuration: ::Rails::Schema.configuration)
+                       configuration: ::Rails::Schema.configuration, view_tables: nil)
           @column_reader = column_reader
           @association_reader = association_reader
           @group_proc = configuration.resolved_group_proc
+          @view_tables = view_tables ? Set.new(view_tables) : Set.new
         end
 
         def build(models)
@@ -47,7 +48,8 @@ module Rails
             id: unique_id,
             table_name: model.table_name,
             columns: @column_reader.read(model),
-            group: group
+            group: group,
+            view: @view_tables.include?(model.table_name)
           )
         end
 

--- a/lib/rails/schema/transformer/node.rb
+++ b/lib/rails/schema/transformer/node.rb
@@ -4,18 +4,20 @@ module Rails
   module Schema
     module Transformer
       class Node
-        attr_reader :id, :table_name, :columns, :group
+        attr_reader :id, :table_name, :columns, :group, :view
 
-        def initialize(id:, table_name:, columns: [], group: [])
+        def initialize(id:, table_name:, columns: [], group: [], view: false)
           @id = id
           @table_name = table_name
           @columns = columns
           @group = group
+          @view = view
         end
 
         def to_h
           h = { id: @id, table_name: @table_name, columns: @columns }
           h[:group] = @group unless @group.empty?
+          h[:view] = true if @view
           h
         end
       end

--- a/spec/rails/schema/extractor/column_reader_spec.rb
+++ b/spec/rails/schema/extractor/column_reader_spec.rb
@@ -90,5 +90,32 @@ RSpec.describe Rails::Schema::Extractor::ColumnReader do
         expect(columns.find { |c| c[:name] == "title" }).to be_truthy
       end
     end
+
+    context "with view_tables" do
+      let(:schema_data) do
+        { "messages" => [{ name: "id", type: "", nullable: true, default: nil, primary: false }] }
+      end
+
+      subject(:reader) { described_class.new(schema_data: schema_data, view_tables: ["messages"]) }
+
+      it "prefers live DB columns (with types) over parsed view names" do
+        model = double("View", name: "Message", table_name: "messages", primary_key: "id")
+        db_col = double("Col", name: "id", type: :integer, null: false, default: nil)
+        allow(model).to receive(:columns).and_return([db_col])
+
+        columns = reader.read(model)
+
+        expect(columns).to eq([{ name: "id", type: "integer", nullable: false, primary: true, default: nil }])
+      end
+
+      it "falls back to parsed view column names when no DB connection is available" do
+        model = double("View", name: "Message", table_name: "messages")
+        allow(model).to receive(:columns).and_raise(StandardError, "no db")
+
+        columns = nil
+        expect { columns = reader.read(model) }.to output(/Could not read columns/).to_stderr
+        expect(columns.map { |c| c[:name] }).to eq(["id"])
+      end
+    end
   end
 end

--- a/spec/rails/schema/extractor/structure_sql_parser_spec.rb
+++ b/spec/rails/schema/extractor/structure_sql_parser_spec.rb
@@ -342,6 +342,54 @@ RSpec.describe Rails::Schema::Extractor::StructureSqlParser do
       expect(parser.parse_content("")).to eq({})
     end
 
+    context "with SQL views (CREATE VIEW)" do
+      it "records view names in #views and includes them in the table map" do
+        content = <<~SQL
+          CREATE TABLE "sms" ("id" integer PRIMARY KEY, "to_phone" varchar);
+          CREATE VIEW messages AS
+            SELECT id, to_phone AS recipient FROM sms
+           /* messages(id,recipient) */;
+        SQL
+
+        result = parser.parse_content(content)
+
+        expect(parser.views.to_a).to eq(["messages"])
+        expect(result).to have_key("messages")
+      end
+
+      it "extracts view column names from the SQLite hint comment" do
+        content = <<~SQL
+          CREATE VIEW messages AS
+            SELECT 'sms' AS channel, id, to_phone AS recipient FROM sms
+           /* messages(channel,id,recipient) */;
+        SQL
+
+        result = parser.parse_content(content)
+
+        expect(result["messages"].map { |c| c[:name] }).to eq(%w[channel id recipient])
+        expect(result["messages"].map { |c| c[:type] }).to all(eq(""))
+        expect(result["messages"].none? { |c| c[:primary] }).to be true
+      end
+
+      it "falls back to SELECT-list aliases when no hint comment is present" do
+        content = <<~SQL
+          CREATE VIEW messages AS
+            SELECT 'sms' AS channel, id, to_phone AS recipient, NULL AS subject FROM sms;
+        SQL
+
+        result = parser.parse_content(content)
+
+        expect(result["messages"].map { |c| c[:name] }).to eq(%w[channel id recipient subject])
+      end
+
+      it "resets #views between parses" do
+        parser.parse_content("CREATE VIEW v AS SELECT id FROM t /* v(id) */;")
+        parser.parse_content("CREATE TABLE \"t\" (\"id\" integer PRIMARY KEY);")
+
+        expect(parser.views.to_a).to be_empty
+      end
+    end
+
     context "with SQLite-format dumps (whole table on one line)" do
       it "parses all columns from a single-line CREATE TABLE" do
         content = <<~SQL

--- a/spec/rails/schema/transformer/graph_builder_spec.rb
+++ b/spec/rails/schema/transformer/graph_builder_spec.rb
@@ -249,4 +249,28 @@ RSpec.describe Rails::Schema::Transformer::GraphBuilder do
       expect(edge[:from]).to eq("HABTM_Things (things_roles)")
     end
   end
+
+  describe "#build with view_tables" do
+    let(:column_reader) { instance_double(Rails::Schema::Extractor::ColumnReader) }
+    let(:association_reader) { instance_double(Rails::Schema::Extractor::AssociationReader) }
+    let(:view_model) { double("Message", name: "Message", table_name: "messages") }
+    let(:table_model) { double("Account", name: "Account", table_name: "accounts") }
+
+    let(:builder) do
+      described_class.new(column_reader: column_reader, association_reader: association_reader,
+                          view_tables: ["messages"])
+    end
+
+    before do
+      allow(column_reader).to receive(:read).and_return([])
+      allow(association_reader).to receive(:read).and_return([])
+    end
+
+    it "flags nodes whose table is a view and leaves tables unflagged" do
+      result = builder.build([view_model, table_model])
+
+      expect(result[:nodes].find { |n| n[:id] == "Message" }[:view]).to be true
+      expect(result[:nodes].find { |n| n[:id] == "Account" }).not_to have_key(:view)
+    end
+  end
 end

--- a/spec/rails/schema/transformer/node_spec.rb
+++ b/spec/rails/schema/transformer/node_spec.rb
@@ -13,5 +13,17 @@ RSpec.describe Rails::Schema::Transformer::Node do
 
       expect(node.to_h).not_to have_key(:group)
     end
+
+    it "includes view: true when the node is a view" do
+      node = described_class.new(id: "Message", table_name: "messages", view: true)
+
+      expect(node.to_h[:view]).to be true
+    end
+
+    it "omits view when false" do
+      node = described_class.new(id: "User", table_name: "users")
+
+      expect(node.to_h).not_to have_key(:view)
+    end
   end
 end

--- a/spec/rails/schema_spec.rb
+++ b/spec/rails/schema_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Rails::Schema do
     let(:graph_data) { { nodes: [], edges: [], metadata: {} } }
     let(:output_path) { "/tmp/schema.html" }
 
-    let(:ruby_parser) { instance_double(Rails::Schema::Extractor::SchemaFileParser, parse: schema_data) }
+    let(:ruby_parser) { instance_double(Rails::Schema::Extractor::SchemaFileParser, parse: schema_data, views: []) }
     let(:scanner) { instance_double(Rails::Schema::Extractor::ModelScanner, scan: models) }
     let(:column_reader) { instance_double(Rails::Schema::Extractor::ColumnReader) }
     let(:graph_builder) { instance_double(Rails::Schema::Transformer::GraphBuilder, build: graph_data) }
@@ -82,7 +82,8 @@ RSpec.describe Rails::Schema do
       Rails::Schema.generate
 
       expect(Rails::Schema::Extractor::ModelScanner).to have_received(:new).with(schema_data: schema_data)
-      expect(Rails::Schema::Extractor::ColumnReader).to have_received(:new).with(schema_data: schema_data)
+      expect(Rails::Schema::Extractor::ColumnReader).to have_received(:new)
+        .with(schema_data: schema_data, view_tables: [])
     end
 
     it "sets mode to active_record in graph metadata" do
@@ -179,8 +180,8 @@ RSpec.describe Rails::Schema do
     let(:ruby_data) { { "users" => [{ name: "id", type: "integer" }] } }
     let(:sql_data) { { "posts" => [{ name: "id", type: "bigint" }] } }
 
-    let(:ruby_parser) { instance_double(Rails::Schema::Extractor::SchemaFileParser, parse: ruby_data) }
-    let(:sql_parser) { instance_double(Rails::Schema::Extractor::StructureSqlParser, parse: sql_data) }
+    let(:ruby_parser) { instance_double(Rails::Schema::Extractor::SchemaFileParser, parse: ruby_data, views: []) }
+    let(:sql_parser) { instance_double(Rails::Schema::Extractor::StructureSqlParser, parse: sql_data, views: []) }
 
     let(:scanner) { instance_double(Rails::Schema::Extractor::ModelScanner, scan: []) }
     let(:column_reader) { instance_double(Rails::Schema::Extractor::ColumnReader) }
@@ -234,7 +235,7 @@ RSpec.describe Rails::Schema do
     end
 
     context "when schema_format is :auto and ruby file returns empty hash" do
-      let(:ruby_parser) { instance_double(Rails::Schema::Extractor::SchemaFileParser, parse: {}) }
+      let(:ruby_parser) { instance_double(Rails::Schema::Extractor::SchemaFileParser, parse: {}, views: []) }
 
       before do
         Rails::Schema.configure { |c| c.schema_format = :auto }
@@ -251,8 +252,8 @@ RSpec.describe Rails::Schema do
     end
 
     context "when both parsers return empty hashes" do
-      let(:ruby_parser) { instance_double(Rails::Schema::Extractor::SchemaFileParser, parse: {}) }
-      let(:sql_parser) { instance_double(Rails::Schema::Extractor::StructureSqlParser, parse: {}) }
+      let(:ruby_parser) { instance_double(Rails::Schema::Extractor::SchemaFileParser, parse: {}, views: []) }
+      let(:sql_parser) { instance_double(Rails::Schema::Extractor::StructureSqlParser, parse: {}, views: []) }
 
       before do
         Rails::Schema.configure { |c| c.schema_format = :auto }


### PR DESCRIPTION
## Problem

A model backed by a SQL **view** (e.g. `self.table_name = "notification_messages"` over a `CREATE VIEW`) was silently dropped from the diagram. Two reasons:

1. `StructureSqlParser` parsed `CREATE TABLE` but never `CREATE VIEW`, so the view name was absent from `schema_data`.
2. `ModelScanner#table_known?` only keeps models whose `table_name` is a key in `schema_data` — so the view-backed model failed the filter and never reached the GraphBuilder.

## What this adds

- **Parsing** — `StructureSqlParser` now also parses `CREATE VIEW`. View names are exposed via `#views` (a `Set`); view column names come from the SQLite hint comment (`/* viewname(col,...) */`) or, as a fallback, the `SELECT` list.
- **Columns** — `parse_schema` returns `[columns, view_names]`. `ColumnReader.new(view_tables:)` reads view columns from **live DB introspection first** (accurate types) and falls back to the parsed names when no DB connection is available. This satisfies both the rake task (DB present → real types) and offline/CI runs (names only).
- **Graph** — `GraphBuilder.new(view_tables:)` sets `Node#view`, serialized as `view: true` only for views.
- **Frontend** — view nodes get a "VIEW" badge, a dashed border, and a "VIEW" tag in the detail panel.

Views are **always included** — no new config flag. A model just needs `self.table_name` pointing at the view. Existing `exclude_models` / `exclude_model_if` still apply.

## Verification

Regenerated a real SQLite app's diagram: the view-backed model now appears with all 13 columns (real DB types), flagged as a view, with its `belongs_to :account` edge rendered.

198 examples, 0 failures; RuboCop clean. New specs cover view parsing (hint comment + SELECT-list fallback + `#views` reset), `ColumnReader` DB-first/offline-fallback behavior, and the `Node`/`GraphBuilder` view flag.

Released under the unreleased **0.1.8** (alongside the SQLite parsing fix from #34).

🤖 Generated with [Claude Code](https://claude.com/claude-code)